### PR TITLE
Display reason for stream error in log

### DIFF
--- a/src/xmpp-proxy.js
+++ b/src/xmpp-proxy.js
@@ -289,7 +289,7 @@ dutil.copy(XMPPProxy.prototype, {
 	},
 
 	_on_stream_error: function(error) {
-		log.error("%s %s _on_stream_error - will terminate: %s", this._void_star.session.sid, this._void_star.name);
+		log.error("%s %s _on_stream_error - will terminate: %s", this._void_star.session.sid, this._void_star.name, error);
 		this.terminate();
 	},
 


### PR DESCRIPTION
Just added in the error var to the log.error() call as it was missing
