### PR TITLE
update ltx dependency to v0.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "author": "Dhruv Matani",
   "dependencies": {
     "node-expat": "~2.0.0",
-    "ltx": "~0.1.2",
+    "ltx": "~0.2.2",
     "node-uuid": "~1.3.3",
     "tav": "~0.1.0",
     "underscore": "~1.3.3",


### PR DESCRIPTION
I found some strange behavior with `ltx` v0.1.3 & `strophe.js` & websockets. Unfortunately I could not determine the problem yet. Updating `ltx` to v0.2.2 seems to solve the problem.

Do you mind to update the dependency?
