### PR TITLE
Further stream close improvements; addition of WebSocket ping

### DIFF
--- a/src/websocket.js
+++ b/src/websocket.js
@@ -273,8 +273,8 @@ exports.createServer = function(bosh_server, webSocket) {
                 wsep.emit('stream-terminate', sstate);
             }
 
-			// This code is run regardless of which end closed the stream
-            clearInterval(pingTimerId);
+            // This code is run regardless of which end closed the stream
+            clearInterval(sstate.pingTimerId);
             wsep.stat_stream_terminate();
         });
         

--- a/src/websocket.js
+++ b/src/websocket.js
@@ -157,7 +157,7 @@ exports.createServer = function(bosh_server, webSocket) {
                 sid: "WEBSOCKET"
             },
             has_open_stream_tag: false,
-            sstate.lastPong: Date.now(),
+            lastPong: Date.now(),
             pingTimerId: setInterval(function () {
                 if (Date.now() - sstate.lastPong > 60000) {
                     log.warn("%s no pong - closing stream", stream_name);


### PR DESCRIPTION
I was seeing some server restarts on occasion when a websocket client closes a connection - the XMPP server would attempt to distribute the unavailable presence, and this would get passed to the closed websocket server, throwing an uncaught exception.

In attempting to fix this, I ended up reworking a lot of the stream/connection close code - it should now be compliant with section 3.5 of draft-moffitt-xmpp-over-websocket-03 (i.e. respond to a stream close with another stream close, and let the initiator send the websocket close frame).

It also now sends a websocket ping frame every thirty seconds for each connection, and checks for the 'pong' response.  This is for the following reasons:
- Keep idle sessions from getting dropped by intermediate load balancers/proxies/NAT firewalls.
- Close the connection if the client disappears unexpectedly.
