### PR TITLE
WebSocket xmpp sub protocol support

### DIFF
--- a/src/websocket.js
+++ b/src/websocket.js
@@ -87,8 +87,17 @@ exports.createServer = function(bosh_server, options, webSocket) {
     
     var websocket_server = new webSocket.Server({
         server:  bosh_server.server,
+        handleProtocols: function(protocols, callback) {
+            var protocol;
+            for (var i = 0; i < protocols.length; i++) {
+                if (protocols[i] === 'xmpp' || protocols[i] === '') {
+                    protocol = protocols[i];
+                    break;
+                }
+            }
+            callback(protocol !== undefined, protocol || undefined);
+        },
         // autoAcceptConnections: true,
-        // subprotocol: 'xmpp'
     });
     
     wsep.server = websocket_server;


### PR DESCRIPTION
Starting with version 30, Chrome throw an exception if there is a sub-protocol mismatch:

> WebSocket connection to 'XXX' failed: Error during WebSocket handshake: Sec-WebSocket-Protocol mismatch lightstring.js:927

This patch allows connections with undefined sub protocol and xmpp sub protocol.
If the xmpp sub protocol was specified, it is sent back during the handshake.
