### PR TITLE
Server connections using route attribute not working

### DIFF
--- a/src/lookup-service.js
+++ b/src/lookup-service.js
@@ -123,7 +123,7 @@ dutil.copy(XMPPLookupService.prototype, {
             // First just connect to the server if this._route is defined.
             if (self._route) {
                 log.trace('try_connect_route - %s:%s', self._route.host, self._route.port);
-                var emitter = SRV.connect(socket, [ ], self._domain_name, self._port);
+                var emitter = SRV.connect(socket, [ ], self._route.host, self._route.port);
 
                 emitter.once('connect', on_success);
                 emitter.once('error',   on_error);


### PR DESCRIPTION
This change makes connections to a server defined in the route attribute work again.
