### PR TITLE
allow DEFAULT_XMPP_PORT env to be set for 12-factor deployments

### DIFF
--- a/src/xmpp-proxy-connector.js
+++ b/src/xmpp-proxy-connector.js
@@ -35,7 +35,7 @@ var path		= require('path');
 var filename	= path.basename(path.normalize(__filename));
 var log			= require('./log.js').getLogger(filename);
 
-var DEFAULT_XMPP_PORT = 5222;
+var DEFAULT_XMPP_PORT = process.env.DEFAULT_XMPP_PORT || 5222;
 
 
 


### PR DESCRIPTION
If there is a way to override the port with the boshUrl, please let me know, at the moment this is the only way I could see to change the upstream XMPP service port number.
