### PR TITLE
Support ENV switchable xmpp port / simpler DNS SRV lookup

### DIFF
--- a/src/lookup-service.js
+++ b/src/lookup-service.js
@@ -109,6 +109,7 @@ dutil.copy(XMPPLookupService.prototype, {
 
         var connectors = [
             try_connect_route,
+            try_connect_domain,
             try_connect_SRV_lookup,
             give_up_trying_to_connect
         ];
@@ -132,6 +133,17 @@ dutil.copy(XMPPLookupService.prototype, {
                 // Trigger the 'error' event.
                 on_error();
             }
+        }
+
+        function try_connect_domain(on_success, on_error) {
+            log.trace('try_connect_domain_lookup - %s, %s',self._domain_name, self._port);
+
+            // Then try a normal SRV lookup.
+            var emitter = SRV.connect(socket, [],
+                                      self._domain_name, self._port);
+
+            emitter.once('connect', on_success);
+            emitter.once('error',   on_error);
         }
 
         function try_connect_SRV_lookup(on_success, on_error) {

--- a/src/xmpp-proxy-connector.js
+++ b/src/xmpp-proxy-connector.js
@@ -35,7 +35,7 @@ var path		= require('path');
 var filename	= path.basename(path.normalize(__filename));
 var log			= require('./log.js').getLogger(filename);
 
-var DEFAULT_XMPP_PORT = 5222;
+var DEFAULT_XMPP_PORT = process.env.DEFAULT_XMPP_PORT || 5222;
 
 
 


### PR DESCRIPTION
This helps when deploying to flynn: https://github.com/flynn/flynn

I think there might be a better approach to the ENV if i can figure out where to parse out the `jid` then we could just support `jid: foo@bar:1234` as usernames
