### PR TITLE
Use open/close tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ if the *callback=* GET query parameter is supplied.
 
 * [http://xmpp.org/extensions/xep-0124.html](http://xmpp.org/extensions/xep-0124.html)
 * [http://xmpp.org/extensions/xep-0206.html](http://xmpp.org/extensions/xep-0206.html)
-* [http://tools.ietf.org/html/draft-moffitt-xmpp-over-websocket-00](http://tools.ietf.org/html/draft-moffitt-xmpp-over-websocket-00)
+* [https://tools.ietf.org/html/draft-ietf-xmpp-websocket-10](https://tools.ietf.org/html/draft-ietf-xmpp-websocket-10)
 
 
 ### Dependencies
@@ -278,6 +278,7 @@ if the *callback=* GET query parameter is supplied.
     4. libpurple (pidgin as a client)
     5. [strophe.js websocket client] (https://github.com/superfeedr/strophejs/tree/protocol-ed) [broken link]
     6. [node-xmpp] (https://github.com/astro/node-xmpp)
+    7. [stanza.io] (https://github.com/otalk/stanza.io)
 
 
 ### Tested using

--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ Note: The **=** sign is important here. Replacing the equal sign with a space wi
 
 * **websocket_ping_interval**: The period, in seconds, between sending WebSocket ping frames to each client. If a client fails to respond with a pong frame twice in a row, the connection will be closed. Set to 0 to disable sending of WebSocket pings. **(default: 30)**
 
+* **use_stream_tags**: Set to 'true' to enable the use of legacy `<stream>` tags instead of `<open>` and `<close>`. You may need this if your client is not up to date with the spec. **(default: false)**
+
 ### Architecture
 
 The project itself is divided into 4 main components as of now.

--- a/bosh.conf.example.js
+++ b/bosh.conf.example.js
@@ -98,5 +98,8 @@ exports.config = {
 	// client. If a client fails to respond with a pong frame twice in a row,
 	// the connection will be closed.
 	// Set to 0 to disable sending of WebSocket pings.
-	websocket_ping_interval: 30
+	websocket_ping_interval: 30,
+
+	// Set to true to use legacy <stream> tags instead of <open> and <close>
+	use_stream_tags: false,
 };

--- a/src/websocket.js
+++ b/src/websocket.js
@@ -131,6 +131,12 @@ exports.createServer = function(bosh_server, options, webSocket) {
         if (sstate.has_open_stream_tag) {
             ss_xml = ss_xml.replace('/>', '>');
         }
+
+        if(!use_stream_tags) {
+            ss_xml = ss_xml.replace('<stream:stream', '<open');
+            ss_xml = ss_xml.replace('xmlns="jabber:client"', 'xmlns="urn:ietf:params:xml:ns:xmpp-framing"');
+        }
+
         log.trace("%s sending stream:stream tag on stream restart: %s", sstate.name, ss_xml);
         wsep.emit('response', ss_xml, sstate);
     });


### PR DESCRIPTION
I ran into issues trying to use node-xmpp-bosh along with current versions of Strophe.js that use open and close tags instead of the legacy stream ones. I noticed #117 resolved the issue, but has not been merged due to backward compatibility concerns. I expanded on that change to allow a configuration option to support legacy clients so that hopefully this can be merged. Thanks!
