### PR TITLE
Allow option to disable XMPP SRV lookups in case they do not exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ Note: The **=** sign is important here. Replacing the equal sign with a space wi
 
 * **no_tls_domains**: A list of Domains for which TLS should NOT be used if the XMPP server supports STARTTLS but does NOT require it **(default: [ ])**
 
+* **no_srv**: Set to 'true' to disable the `_xmpp-client._tcp` SRV lookup and just resolve the hostname instead. **(default: false)**
+
 * **firewall**: An object (map) of type { allow: [ list... ], deny: [ list... ] }, where [ list... ] means an array of strings or regular expressions which are tested against the domain connected to. ONLY One of the 2 (deny or allow) shall be used depending on which array has values. The one that is non-empty shall be used. If both are empty (default), all connections are allowed. If both are non-empty, then the ALLOW list is used and ONLY connections to the domains listed in ALLOW are connected to **(default: { allow: [ ], deny: [ ] })**
 
 * **route_filter**: If the route attribute is set, allow connections ONLY if the route attribute matches the regex below **(default: /.\*/)**

--- a/bosh.conf.example.js
+++ b/bosh.conf.example.js
@@ -48,6 +48,10 @@ exports.config = {
 	// 
 	no_tls_domains: [ /* 'chat.facebook.com' */ ], 
 
+	// Set to 'true' to disable the '_xmpp-client._tcp' SRV lookup and
+	// just resolve the hostname instead.
+	no_srv: false,
+
 	//
 	// A list of domains (string or regex) to either deny or allow
 	// connections to.

--- a/run-server.js
+++ b/run-server.js
@@ -76,6 +76,10 @@ function main() {
 			note: "The host on which to the BOSH server should listen for connections (default: 0.0.0.0)", 
 			value: -1
 		}, 
+		no_srv: {
+			note: "Pass 'true' to disable the '_xmpp-client._tcp' SRV lookup and just resolve the hostname instead",
+			value: -1
+		},
 		version: {
 			note: "Display version info and exit", 
 			value: false
@@ -155,6 +159,15 @@ function main() {
 	}
 	else {
 		server_options.logging = opts.logging.toUpperCase();
+	}
+
+	if (opts.no_srv === -1) {
+		if(!server_options.no_srv) {
+			server_options.no_srv = false;
+		}
+	}
+	else {
+		server_options.no_srv = true;
 	}
 
     // Set the default line trim length.

--- a/src/lookup-service.js
+++ b/src/lookup-service.js
@@ -55,11 +55,12 @@ var log         = require('./log.js').getLogger(filename);
  *         the following fields: 'route'
  *
  */
-function XMPPLookupService(port, stream, route_filter) {
+function XMPPLookupService(port, stream, route_filter, no_srv) {
     this._domain_name = stream.to;
     this._port = port;
     this._route = stream.route;
     this._allow_connect = true;
+    this._no_srv = !!no_srv;
 
     var _special = {
         "gmail.com": "talk.google.com",
@@ -138,7 +139,7 @@ dutil.copy(XMPPLookupService.prototype, {
             log.trace('try_connect_SRV_lookup - %s, %s',self._domain_name, self._port);
 
             // Then try a normal SRV lookup.
-            var emitter = SRV.connect(socket, ['_xmpp-client._tcp'],
+            var emitter = SRV.connect(socket, self._no_srv ? [ ] : ['_xmpp-client._tcp'],
                                       self._domain_name, self._port);
 
             emitter.once('connect', on_success);

--- a/src/main.js
+++ b/src/main.js
@@ -102,6 +102,6 @@ exports.start_websocket = function(bosh_server, options, webSocket) {
 
 	// The connector is responsible for communicating with the real XMPP server.
 	// We allow different types of connectors to exist.
-	var conn = new xpc.Connector(ws_server, { });
+	var conn = new xpc.Connector(ws_server, options);
     return ws_server;
 };

--- a/src/xmpp-proxy-connector.js
+++ b/src/xmpp-proxy-connector.js
@@ -163,7 +163,7 @@ XMPPProxyConnector.prototype = {
 		}
 
 		var _ls_ctor = this.options.lookup_service || lookup.LookupService;
-		var _ls      = new _ls_ctor(DEFAULT_XMPP_PORT, stream);
+		var _ls      = new _ls_ctor(DEFAULT_XMPP_PORT, stream, this.options.route_filter, this.options.no_srv);
 
 		// Create a new stream.
 		var proxy = new this.Proxy(stream.to, _ls, stream.attrs, 


### PR DESCRIPTION
The DNS entry of the server we are attempting to connect to does not have a SRV record for `_xmpp-client._tcp`, which causes the connection to hang indefinitely. This allows passing an option to disable that functionality. #124 also works for me, but if the hostname lookup fails I do not want to try SRV next since it seems to hang. Threading these options through was a bit difficult, so let me know if you think it should be done in a different way. It also looks like `route_filter` was not properly being threaded through to the lookup service, so I modified that as well. Thanks!
